### PR TITLE
Revert bash-language-server from 4.9.2 to 4.10.0

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "bash-language-server": "^4.10.0"
+        "bash-language-server": "^4.9.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/bash-language-server": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/bash-language-server/-/bash-language-server-4.10.0.tgz",
-      "integrity": "sha512-MGrf+vbu1HQa2t8BRQQ1RjtryWOOxzumpyuv0QGNpMGHGmHj4lv2iIitNaseo2cuUyQ/cVLZkj6LMnAZl5kByQ==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/bash-language-server/-/bash-language-server-4.9.2.tgz",
+      "integrity": "sha512-WchUA3WdUbgocLSJddbmECbkfHxp7hNFbFh7rLaPbqVsL9506HZYumlOQq1fcPGss1iTshJtQYyPzNsPV3XZag==",
       "dependencies": {
         "fast-glob": "3.2.12",
         "fuzzy-search": "3.2.1",
@@ -369,9 +369,9 @@
       }
     },
     "bash-language-server": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/bash-language-server/-/bash-language-server-4.10.0.tgz",
-      "integrity": "sha512-MGrf+vbu1HQa2t8BRQQ1RjtryWOOxzumpyuv0QGNpMGHGmHj4lv2iIitNaseo2cuUyQ/cVLZkj6LMnAZl5kByQ==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/bash-language-server/-/bash-language-server-4.9.2.tgz",
+      "integrity": "sha512-WchUA3WdUbgocLSJddbmECbkfHxp7hNFbFh7rLaPbqVsL9506HZYumlOQq1fcPGss1iTshJtQYyPzNsPV3XZag==",
       "requires": {
         "fast-glob": "3.2.12",
         "fuzzy-search": "3.2.1",

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "bash-language-server": "^4.10.0"
+    "bash-language-server": "^4.9.2"
   }
 }


### PR DESCRIPTION
This reverts commit b8f3fcfaa2c3b474c87e3b61c1664cddc04db378.

Latest version crashes for me on Mac and there is also report on Discord that it happens on Windows.

```
LSP-bash: TypeError: Cannot read properties of undefined (reading 'apply')
LSP-bash:     at e.<computed> (/Users/rafal/Library/Caches/Sublime Text/Package Storage/LSP-bash/16.17.1/language-server/node_modules/web-tree-sitter/tree-sitter.js:1:16465)
LSP-bash:     at wasm://wasm/001ec906:wasm-function[21]:0x1ccf
LSP-bash:     at e.<computed> (/Users/rafal/Library/Caches/Sublime Text/Package Storage/LSP-bash/16.17.1/language-server/node_modules/web-tree-sitter/tree-sitter.js:1:16465)
LSP-bash:     at wasm://wasm/001ec906:wasm-function[19]:0x17aa
LSP-bash:     at wasm://wasm/000b627a:wasm-function[234]:0x25842
LSP-bash:     at Module._ts_parser_parse_wasm (/Users/rafal/Library/Caches/Sublime Text/Package Storage/LSP-bash/16.17.1/language-server/node_modules/web-tree-sitter/tree-sitter.js:1:33493)
LSP-bash:     at Parser.parse (/Users/rafal/Library/Caches/Sublime Text/Package Storage/LSP-bash/16.17.1/language-server/node_modules/web-tree-sitter/tree-sitter.js:1:53325)
LSP-bash:     at Analyzer.analyze (/Users/rafal/Library/Caches/Sublime Text/Package Storage/LSP-bash/16.17.1/language-server/node_modules/bash-language-server/out/analyser.js:47:34)
LSP-bash:     at BashServer.<anonymous> (/Users/rafal/Library/Caches/Sublime Text/Package Storage/LSP-bash/16.17.1/language-server/node_modules/bash-language-server/out/server.js:241:45)
LSP-bash:     at Generator.next (<anonymous>)
```