### PR TITLE
chore: pin specific package version

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "bash-language-server": "^5.4.3"
+        "bash-language-server": "5.4.3"
       }
     },
     "node_modules/@mixmark-io/domino": {

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "bash-language-server": "^5.4.3"
+    "bash-language-server": "5.4.3"
   }
 }


### PR DESCRIPTION
Pinning specific version. This is not strictly needed since version is pinned through the lock file but having it pinned in package.json should provide better visibility in renovate PRs.