### PR TITLE
fix: don't show server version by default

### DIFF
--- a/LSP-bash.sublime-settings
+++ b/LSP-bash.sublime-settings
@@ -58,7 +58,8 @@
 
 		// The (Jinja2) template of the status bar text which is inside the parentheses `(...)`.
 		// See https://jinja.palletsprojects.com/templates/
-		"statusText": "{% if server_version %}v{{ server_version }}{% endif %}",
+		// Set to "{% if server_version %}v{{ server_version }}{% endif %}" to show server version.
+		"statusText": "",
 	},
 	// The path to the server binary used to start the language server.
 	// Use `auto` for the package to manage (install/update) the server automatically.

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -128,7 +128,7 @@
 
 										"statusText": {
 											"type": "string",
-											"default": "{% if server_version %}v{{ server_version }}{% endif %}",
+											"default": "",
 											"markdownDescription": "The (Jinja2) template of the status bar text which is inside the parentheses `(...)`."
 										}
 									}


### PR DESCRIPTION
Consumers of this package don't really need to know the server version by default and have it take valuable status space.